### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 A TypeScript-based Model Context Protocol (MCP) server designed to streamline Gel database operations with EdgeQL queries. This project provides Tools for LLM Agents (Cursor Agent, Claude Code, etc) to automate learning about your schema, and writing, validating, and executing database queries. Easily interact with your Gel database through natural language. Vibe coders rejoice! 
 
+<a href="https://glama.ai/mcp/servers/@christian561/gel-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@christian561/gel-mcp-server/badge" alt="Gel Database Server MCP server" />
+</a>
 
 Note: Query generation is not included since LLMs can write more flexible queries. Tested this with Cursor agent using Claude-3.7-sonnet-thinking and had good results after providing Gel docs by linking the relevant webpages. 
 


### PR DESCRIPTION
This PR adds a badge for the [Gel Database MCP Server](https://glama.ai/mcp/servers/@christian561/gel-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@christian561/gel-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@christian561/gel-mcp-server/badge" alt="Gel Database Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.